### PR TITLE
Fix write function implementation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -225,12 +225,12 @@ class Client
 	 * Update model(s)
 	 *
 	 * @param string $model  Model
-	 * @param array  $id     Model id to update
+	 * @param array  $ids     Model ids to update
 	 * @param array  $fields A associative array (format: ['field' => 'value'])
 	 *
 	 * @return array
 	 */
-	public function write($model, $id, $fields)
+	public function write($model, $ids, $fields)
 	{
         $response = $this->getClient('object')->execute_kw(
             $this->database,
@@ -239,7 +239,7 @@ class Client
             $model,
             'write',
             [
-                 [$id],
+                 $ids,
                 $fields
             ]
         );


### PR DESCRIPTION
https://www.odoo.com/documentation/10.0/api_integration.html

$models->execute_kw($db, $uid, $password, 'res.partner', 'write',
    array(array($id), array('name'=>"Newer partner")));

Passing an array of ids ($id parameter) was causing a web call failure #2 due to the $id variable being stored in an array  